### PR TITLE
Fixed firefox click event path bug

### DIFF
--- a/src/trackers/click.js
+++ b/src/trackers/click.js
@@ -14,15 +14,18 @@ const getPath = (path) => {
     .join(' > ')
 }
 
-const clickEvent = ({path, target}) => {
-  const trackable = path[0].childElementCount < 3
-  if (trackable) {
-    api.logEvent({
-      evt: 'CLICK',
-      uri: location.href,
-      path: getPath(path),
-      innerHTML: target.innerHTML,
-    })
+const clickEvent = (event) => {
+  const path = event.path || event.composedPath && event.composedPath()
+  if (path) {
+    const trackable = path[0].childElementCount < 3
+    if (trackable) {
+      api.logEvent({
+        evt: 'CLICK',
+        uri: location.href,
+        path: getPath(path),
+        innerHTML: event.target.innerHTML,
+      })
+    }
   }
 }
 


### PR DESCRIPTION
event.path on firefox click event doesn't exist.

created workaround to get path from event.composedPath function.